### PR TITLE
Refactor room geometry loops in LevelMath

### DIFF
--- a/src/LevelMath.cpp
+++ b/src/LevelMath.cpp
@@ -52,9 +52,10 @@ float PointToLineSqDistance(const v2f& pt, const v2f& p1, const v2f& p2)
 float RoomPerimeter(const CRoom& room1)
 {
     float contactArea = 0.f;
-    for (int i = 0; i < room1.GetNumOfEdges(); i++)
+    const int numEdges = room1.GetNumOfEdges();
+    for (int i = 0; i < numEdges; ++i)
     {
-        CRoomEdge edge1 = room1.GetEdge(i);
+        const CRoomEdge edge1 = room1.GetEdge(i);
         contactArea += edge1.GetLength();
     }
 
@@ -64,18 +65,23 @@ float RoomPerimeter(const CRoom& room1)
 float RoomContact(const CRoom& room1, const CRoom& room2)
 {
     float contactArea = 0.f;
-    for (int i = 0; i < room1.GetNumOfEdges(); i++)
+    const int numEdges1 = room1.GetNumOfEdges();
+    const int numEdges2 = room2.GetNumOfEdges();
+    for (int i = 0; i < numEdges1; ++i)
     {
-        CRoomEdge edge1 = room1.GetEdge(i);
-        for (int j = 0; j < room2.GetNumOfEdges(); j++)
+        const CRoomEdge edge1 = room1.GetEdge(i);
+        if (!edge1.GetDoorFlag())
         {
-            CRoomEdge edge2 = room2.GetEdge(j);
-            if (edge1.GetDoorFlag() == false || edge2.GetDoorFlag() == false)
+            continue;
+        }
+        for (int j = 0; j < numEdges2; ++j)
+        {
+            const CRoomEdge edge2 = room2.GetEdge(j);
+            if (!edge2.GetDoorFlag())
             {
                 continue;
             }
-            float contactAreaTmp = EdgeContact(edge1, edge2);
-            contactArea += contactAreaTmp;
+            contactArea += EdgeContact(edge1, edge2);
         }
     }
 
@@ -85,17 +91,23 @@ float RoomContact(const CRoom& room1, const CRoom& room2)
 float RoomContact(const CRoom& room1, const CRoom& room2, int& edgeIdx1, int& edgeIdx2)
 {
     float contactAreaMax = 0.f;
-    for (int i = 0; i < room1.GetNumOfEdges(); i++)
+    const int numEdges1 = room1.GetNumOfEdges();
+    const int numEdges2 = room2.GetNumOfEdges();
+    for (int i = 0; i < numEdges1; ++i)
     {
-        CRoomEdge edge1 = room1.GetEdge(i);
-        for (int j = 0; j < room2.GetNumOfEdges(); j++)
+        const CRoomEdge edge1 = room1.GetEdge(i);
+        if (!edge1.GetDoorFlag())
         {
-            CRoomEdge edge2 = room2.GetEdge(j);
-            if (edge1.GetDoorFlag() == false || edge2.GetDoorFlag() == false)
+            continue;
+        }
+        for (int j = 0; j < numEdges2; ++j)
+        {
+            const CRoomEdge edge2 = room2.GetEdge(j);
+            if (!edge2.GetDoorFlag())
             {
                 continue;
             }
-            float contactAreaTmp = EdgeContact(edge1, edge2);
+            const float contactAreaTmp = EdgeContact(edge1, edge2);
             if (contactAreaTmp > contactAreaMax)
             {
                 contactAreaMax = contactAreaTmp;
@@ -155,13 +167,15 @@ float EdgeContact(const CLineBase& line1, const CLineBase& line2)
 float RoomDistance(const CRoom& room1, const CRoom& room2)
 {
     float d = 1e10;
-    for (int i = 0; i < room1.GetNumOfVertices(); i++)
+    const int numVertices = room1.GetNumOfVertices();
+    const int numEdges = room2.GetNumOfEdges();
+    for (int i = 0; i < numVertices; ++i)
     {
-        v2f pt = room1.GetVertex(i);
-        for (int j = 0; j < room2.GetNumOfEdges(); j++)
+        const v2f pt = room1.GetVertex(i);
+        for (int j = 0; j < numEdges; ++j)
         {
-            CRoomEdge edge = room2.GetEdge(j);
-            float dTmp = PointToSegmentSqDistance(pt, edge);
+            const CRoomEdge edge = room2.GetEdge(j);
+            const float dTmp = PointToSegmentSqDistance(pt, edge);
             d = min(d, dTmp);
         }
     }

--- a/src/RoomEdge.h
+++ b/src/RoomEdge.h
@@ -43,7 +43,7 @@ public:
 	void SetIdx2(int idx2) { m_idx2 = idx2; }
 
 	void SetDoorFlag(bool flag) { m_doorFlag = flag; }
-	bool GetDoorFlag() { return m_doorFlag; }
+	bool GetDoorFlag() const { return m_doorFlag; }
 
 private:
 	int m_idx1;


### PR DESCRIPTION
### Motivation
- Reduce repeated method calls and simplify control flow in hot geometry helpers to improve readability and small runtime overheads.
- Focus changes on perimeter/contact/distance helpers which iterate room edges/vertices and are called frequently in layout code.

### Description
- Cached loop counts from `GetNumOfEdges`/`GetNumOfVertices` and marked loop-local variables `const` to avoid repeated calls and clarify intent in `src/LevelMath.cpp`.
- Reordered checks to early-skip non-door edges in both `RoomContact` overloads and removed unnecessary temporary accumulation variables to simplify nested loops.
- Applied small readability and const-correctness improvements for locals such as `CRoomEdge` and vertex/point temporaries in the modified functions.

### Testing
- Attempted to configure and build with `cmake -S . -B build && cmake --build build -j2`, but configuration failed due to missing Boost `Boost_INCLUDE_DIR`/`thread` components in the environment so compilation could not be verified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0263a93eac832598b7f7569ed5920a)