### PR TITLE
Make CRoomEdge::GetDoorFlag() const

### DIFF
--- a/src/RoomEdge.h
+++ b/src/RoomEdge.h
@@ -43,7 +43,7 @@ public:
 	void SetIdx2(int idx2) { m_idx2 = idx2; }
 
 	void SetDoorFlag(bool flag) { m_doorFlag = flag; }
-	bool GetDoorFlag() { return m_doorFlag; }
+	bool GetDoorFlag() const { return m_doorFlag; }
 
 private:
 	int m_idx1;


### PR DESCRIPTION
### Motivation
- Ensure const-correctness so `GetDoorFlag()` can be called on `const CRoomEdge` instances and to document that the accessor does not modify object state.

### Description
- Change the `GetDoorFlag()` signature in `src/RoomEdge.h` from `bool GetDoorFlag()` to `bool GetDoorFlag() const`.

### Testing
- Project build completed (`make`) and the existing automated unit test suite was run and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a026f747e50832585d53736ad13d752)